### PR TITLE
Remove -O tag from curl command. Fixes issue #27.

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -1,15 +1,107 @@
-#' downloadEncode is use to download  a serie of files or dataset 
-#' by their accession. 
-#' @param file_acc A \code{character} of ENCODE file accession or 
-#' experiment accession. Can also be a data.table coming from any ENCODExplorer
-#' research function.
-#' @param df The reference \code{data.table} use to find the download. File 
-#' that are not available will be search directly throught the current
+#' download_single_file Downloads a single file and checks if md5 checksums match.
+#' @param file_url A \code{character} giving the URL of the file to be downloaded.
+#' @param file_md5 A \code{character} giving the expected md5 checksum hash of the
+#'   file to be downloaded.
+#' @param dir The directory where the downloaded file should be saved. Default: "."
+#' @param experiment_name An optional experiment name to be displayed with the 
+#'   status reports.
+#' @param force \code{boolean} indicating if existing files should be downloaded 
+#'   again. Default : TRUE
+#' 
+#' @return A \code{character} with the name of the downloaded file.
+#' 
+#' @import tools
+download_single_file <- function(file_url, file_md5, dir=".", experiment_name=NULL, force=TRUE) {
+  # Determine the output filename.
+  fileName = strsplit(x = file_url, split = "@@download/", fixed = TRUE)[[1]][2]
+  fileName <- paste0(dir,"/", fileName, sep="")
+  
+  # Identify the target URL.
+  href <- as.character(file_url)
+  
+  # Calculate the md5 of the file if it already exists.
+  md5sum_file <- tools::md5sum(paste(dir, fileName, sep="/"))
+  md5sum_encode <- as.character(file_md5)
+  
+  # If the file does not exist, md5 hashes do not match or force=TRUE, download the file.
+  if (force == TRUE | !(file.exists(fileName)) |
+      (file.exists(fileName) & md5sum_file != md5sum_encode)){
+    encode_root = "https://www.encodeproject.org"
+    download_ret = download.file(url=paste0(encode_root, href), quiet=TRUE,
+                             destfile=fileName, method = "curl",
+                             extra = "-L" )
+    
+    # Determine if the download was a success and calculate the md5 hash.
+    if(download_ret != 0 || !file.exists(fileName)) {
+      warning(paste0("Error while downloading ", fileName, " (", download_ret, ")"), 
+            call. = FALSE)
+    } else {
+      md5sum_file = tools::md5sum(paste0(fileName))
+    }
+  }
+  
+  #Validating the download
+  if(is.na(md5sum_file) || (md5sum_file != md5sum_encode)) {
+    warning(paste0("No md5sum match for : ", fileName), 
+            call. = FALSE)
+    return(NULL)
+  }else{
+    if(!is.null(experiment_name)) {
+      print(paste0("Success downloading experiment :", experiment_name,
+            ",file :", fileName))
+    } else {
+      print(paste0("Success downloading file : ", fileName))
+    }
+    return(fileName)
+  }
+}
+
+#' Downloads all files inside a data.table.
+#'
+#' @param input_dt The data.table to be looped over for determining which
+#'   files should be downloaded.
+#' @param dir The path of the directory where the downloaded files should 
+#'   be saved.
+#' @param force If TRUE, existing files are downloaded again.
+#' @param show_experiment If TRUE, the name of the experiment is extracted
+#'   from the data table and displayed in status messages.
+#'
+#' @return The name of the files which were downloaded.
+download_dt_file <- function(input_dt, dir, force, show_experiment=FALSE) {
+  # Track downloaded files.
+  downloaded <- c()
+  if(nrow(input_dt) > 0){
+    for(i in 1:nrow(input_dt)) {
+      if(show_experiment) {
+        experiment_name = input_dt$accession[[i]]
+      } else {
+        experiment_name = NULL
+      }
+    
+      dl.file = download_single_file(file_url=input_dt$href[[i]], 
+                                     file_md5=input_dt$md5sum[[i]],
+                                     dir=dir,
+                                     force=force,
+                                     experiment_name=experiment_name)
+      downloaded <- c(downloaded, dl.file)
+    }
+  }
+  
+  return(downloaded)
+}
+
+#' downloadEncode is used to download a serie of files or datasets 
+#' using their accession. 
+#' @param file_acc A \code{character} of ENCODE file or 
+#' experiment accessions. Can also be a data.table coming from any ENCODExplorer
+#' search function.
+#' @param df The reference \code{data.table} used to find the download. Files 
+#' that are not available will be searched directly through the current
 #' ENCODE database. 
 #' @param format The specific file format to download.
 #' Default : all
 #' @param dir The directory to locate the downloaded files
-#' @param force \code{boolean} the allow to download a file when it already exist
+#' @param force \code{boolean} to allow downloading a file even if it already exists
 #' in the directory. 
 #' Default : TRUE
 #' 
@@ -25,7 +117,6 @@
 #' @importFrom dplyr setdiff
 #' 
 #' @export
-
 downloadEncode <- function (file_acc = NULL, df = NULL, format ="all", dir= ".",
                              force = TRUE) {
   #Extract accession if the user pass a data.table as input
@@ -74,7 +165,7 @@ downloadEncode <- function (file_acc = NULL, df = NULL, format ="all", dir= ".",
   avail_ds <- file_acc[file_acc %in% df$accession]
   unavail <- dplyr::setdiff(file_acc, c(avail_file,avail_ds))
   
-  encode_root = "https://www.encodeproject.org"
+
   
   #Downloading available file from encode_df
   
@@ -105,64 +196,8 @@ downloadEncode <- function (file_acc = NULL, df = NULL, format ="all", dir= ".",
   
   if(file.access(dir, mode = 2) == 0) {
     #Downloading files
-    downloaded <- character()
-    if(nrow(file_dt) > 0){
-      for(i in 1:nrow(file_dt)){
-        fileName = strsplit(x = file_dt$href[[i]],split = "@@download/",fixed = TRUE)[[1]][2]
-        fileName <- paste0(dir,"/", fileName, sep="")
-        href <- as.character(file_dt$href[[i]])
-        md5sum_file <- tools::md5sum(paste(dir, fileName, sep="/"))
-        md5sum_encode <- as.character(file_dt$md5sum[[i]])
-        #Downloading the file
-        if (force == TRUE | !(file.exists(fileName)) |
-            (file.exists(fileName) & md5sum_file != md5sum_encode)){
-          download.file(url=paste0(encode_root, href), quiet=TRUE,
-                                   destfile=fileName, method = "curl",
-                                   extra = "-O -L" )
-          md5sum_file = tools::md5sum(paste0(fileName))
-        }
-        #Validating the download
-        if(md5sum_file != md5sum_encode) {
-          warning(paste0("No md5sum match for : ", fileName), 
-                  call. = FALSE)
-          #Si on as une erreur de telechargement, on tente de supprimer le fichier ?
-        }else{
-          print(paste0("Success downloading file : ", fileName))
-          downloaded <- c(downloaded, fileName)
-        }
-        
-      }
-    }
-    
-    #Downloading experience
-    if(nrow(exp_dt) > 0) {
-      for(i in 1:nrow(exp_dt)){
-        
-        fileName = strsplit(x = exp_dt$href[[i]],split = "@@download/",fixed = TRUE)[[1]][2]
-        fileName <- paste0(dir,"/", fileName, sep="")
-        href <- as.character(exp_dt$href[[i]])
-        md5sum_file <- tools::md5sum(paste(dir, fileName, sep="/"))
-        md5sum_encode <- as.character(exp_dt$md5sum[[i]])
-        
-        if (force == TRUE | !(file.exists(fileName)) |
-            (file.exists(fileName) & md5sum_file != md5sum_encode)){
-          download.file(url=paste0(encode_root, href), quiet=TRUE,
-                        destfile=fileName, method = "curl",
-                        extra = "-O -L" )
-          md5sum_file = tools::md5sum(paste0(fileName))
-        }
-        if(md5sum_file != md5sum_encode) {
-          warning(paste0("No md5sum match for : ", fileName),
-                  call. = FALSE)
-          
-        }else{
-          print(paste0("Success downloading experiment :", unique(exp_dt$accession[[i]]),
-                       ",file :", fileName))
-          downloaded <- c(downloaded, fileName)
-        }
-  
-      }
-    }
+    downloaded <- download_dt_file(file_dt, dir, force, show_experiment=FALSE)
+    downloaded <- c(downloaded, download_dt_file(exp_dt, dir, force, show_experiment=TRUE))
     
     # Step 2 : Handling unavailable files via ENCODE rest-api
     url_search <- "https://www.encodeproject.org/search/?searchTerm="
@@ -189,27 +224,8 @@ downloadEncode <- function (file_acc = NULL, df = NULL, format ="all", dir= ".",
                 next
               }
               
-              fileName = strsplit(x = results$href,split = "@@download/",fixed = TRUE)[[1]][2]
-              fileName <- paste0(dir,"/", fileName, sep="")
-              href <- results$href
-              md5sum_file <- tools::md5sum(paste(dir, fileName, sep="/"))
-              md5sum_restapi <- as.character(results$md5sum)
-              #Downloading the file
-              if (force == TRUE | !(file.exists(fileName)) |
-                  (file.exists(fileName) & md5sum_file != md5sum_restapi)){
-                download.file(url=paste0(encode_root, href), quiet=TRUE,
-                              destfile=fileName, method = "curl",
-                              extra = "-O -L" )
-                md5sum_file = tools::md5sum(paste0(fileName))
-              }
-              #Validating the download
-              if(md5sum_file != md5sum_restapi) {
-                warning(paste0("No md5sum match for : ", fileName),
-                        call. = FALSE)
-              }else{
-                print(paste0("Success downloading file :", fileName))
-                downloaded <- c(downloaded, fileName)
-              }
+              downloaded <- c(downloaded, download_single_file(results$href, results$md5sum, dir, force))
+              
             }else{
               msg <- paste0("No result found for ", unavail[[i]]," with format ", format)
               warning(msg, call. = FALSE)
@@ -238,32 +254,15 @@ downloadEncode <- function (file_acc = NULL, df = NULL, format ="all", dir= ".",
                 if(!is.null(results$href[[y]])){
                   #checking the format
                   if(format != "all" & results$file_format[[y]] != format){next}
-                  fileName = strsplit(x = results$href[[y]],split = "@@download/",fixed = TRUE)[[1]][2]
-                  fileName <- paste0(dir,"/", fileName, sep="")
-                  href <- as.character(results$href[[y]])
-                  md5sum_file <- tools::md5sum(paste(dir, fileName, sep="/"))
-                  md5sum_restapi <- as.character(results$md5sum[[y]])
-                  if (force == TRUE | !(file.exists(fileName)) |
-                      (file.exists(fileName) & md5sum_file != md5sum_restapi)){
-                    download.file(url=paste0(encode_root, href), quiet=TRUE,
-                                  destfile=fileName, method = "curl",
-                                  extra = "-O -L" )
-                    md5sum_file = tools::md5sum(paste0(fileName))
-                  }
-                  #Validating the download
-                  if(md5sum_file != md5sum_restapi) {
-                    warning(paste0("No md5sum match for : ", fileName),
-                            call. = FALSE)
-                  }else{
-                    print(paste0("Success downloading file :", fileName))
-                    downloaded <- c(downloaded, fileName)
-                  }
+                  
+                  downloaded = download_single_file(file_url=results$href[[y]], 
+                                                    file_md5=results$md5sum[[y]], 
+                                                    dir=dir,
+                                                    force=force)
                 }
               }
-              
             }
           }
-            
         
         } else {
           msg <- paste0("No result found for ", unavail[[i]])

--- a/man/downloadEncode.Rd
+++ b/man/downloadEncode.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/download.R
 \name{downloadEncode}
 \alias{downloadEncode}
-\title{downloadEncode is use to download  a serie of files or dataset 
-by their accession.}
+\title{downloadEncode is used to download a serie of files or datasets 
+using their accession.}
 \usage{
 downloadEncode(file_acc = NULL, df = NULL, format = "all", dir = ".",
   force = TRUE)
 }
 \arguments{
-\item{file_acc}{A \code{character} of ENCODE file accession or 
-experiment accession. Can also be a data.table coming from any ENCODExplorer
-research function.}
+\item{file_acc}{A \code{character} of ENCODE file or 
+experiment accessions. Can also be a data.table coming from any ENCODExplorer
+search function.}
 
-\item{df}{The reference \code{data.table} use to find the download. File 
-that are not available will be search directly throught the current
+\item{df}{The reference \code{data.table} used to find the download. Files 
+that are not available will be searched directly through the current
 ENCODE database.}
 
 \item{format}{The specific file format to download.
@@ -22,7 +22,7 @@ Default : all}
 
 \item{dir}{The directory to locate the downloaded files}
 
-\item{force}{\code{boolean} the allow to download a file when it already exist
+\item{force}{\code{boolean} to allow downloading a file even if it already exists
 in the directory. 
 Default : TRUE}
 }
@@ -30,8 +30,8 @@ Default : TRUE}
 A \code{character} with the downloaded files
 }
 \description{
-downloadEncode is use to download  a serie of files or dataset 
-by their accession.
+downloadEncode is used to download a serie of files or datasets 
+using their accession.
 }
 \examples{
  fuzzy_result <- fuzzySearch("ENCSR396EAG", encode_df, filterVector = "accession")


### PR DESCRIPTION
Refactored copy-pasted code into functions and improved english in downloadEncode documentation.