### PR TITLE
Fix #34. Use encode_df when df is null, regardless of parent environment

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -148,8 +148,7 @@ downloadEncode <- function (file_acc = NULL, df = NULL, format ="all", dir= ".",
   stopifnot(length(file_acc) > 0)
   
   if(is.null(df)) {
-    data(encode_df, envir = environment())
-    df <- encode_df
+    df <- ENCODExplorer::encode_df
   }
   
   stopifnot(is.data.table(df))

--- a/R/query.R
+++ b/R/query.R
@@ -127,8 +127,7 @@ queryEncodeGeneric <- function(df = NULL, fixed = TRUE, quiet = FALSE,
   # If no data.frame is provided, use the default one.
   if(is.null(df)) {
     # Load encode_df
-    data(encode_df, envir = environment())
-    df = encode_df
+    df = ENCODExplorer::encode_df
   }
   
   # Gather all search parameters, which are all arguments not explicitly in
@@ -262,7 +261,9 @@ query_transform <- function(my.term) {
 #' @export
 searchToquery <- function(df = NULL, searchResults, quiet = TRUE){
   
-  if(is.null(df)) {data(encode_df, envir = environment())} else {encode_df = df}
+  if(is.null(df)) {
+    df = ENCODExplorer::encode_df
+  }
   
   res = data.frame()
   
@@ -277,7 +278,7 @@ searchToquery <- function(df = NULL, searchResults, quiet = TRUE){
       
       accession <- accessions[i]
       
-      r <- queryEncode(df = encode_df, set_accession = accession, fixed = TRUE, 
+      r <- queryEncode(df = df, set_accession = accession, fixed = TRUE, 
                        quiet = quiet)
       if(!is.null(r)){
         res <- rbind(res,r)


### PR DESCRIPTION
data(encode_df, env=environment()) will fail if called from within a package. Explicit scoping fixes this.